### PR TITLE
Fix image save on iPhone and update move display

### DIFF
--- a/tumego ex.html
+++ b/tumego ex.html
@@ -289,30 +289,53 @@ async function copyBoardImage(){
 
   const blob=new Blob([data],{type:'image/svg+xml'});
   const url=URL.createObjectURL(blob);
-  const img=new Image();
-  img.onload=async()=>{
-    const canvas=document.createElement('canvas');
-    let extra=0;
-    let seq='';
-    if(state.numberMode && state.sgfMoves.length){
-      const letters='ABCDEFGHJKLMNOPQRSTUV'.slice(0,state.boardSize).split('');
-      const colorText={1:'黒',2:'白'};
-      seq=state.sgfMoves.map((m,i)=>{
-        const c=letters[m.col];
-        const r=state.boardSize-m.row;
-        return `${i+1}(${colorText[m.color]}) ${c}${r}`;
-      }).join(' ');
-      extra=50;
-    }
-    canvas.width=img.width;canvas.height=img.height+extra;
-    const ctx=canvas.getContext('2d');
-    ctx.drawImage(img,0,0);
-    if(extra){
-      ctx.fillStyle='#000';
+    const img=new Image();
+    img.onload=async()=>{
+      const canvas=document.createElement('canvas');
+      let seq='';
+      if(state.numberMode && state.sgfMoves.length){
+        const letters='ABCDEFGHJKLMNOPQRSTUV'.slice(0,state.boardSize).split('');
+        const circle=n=>{
+          if(n>=1&&n<=20) return String.fromCharCode(0x2460+n-1);
+          if(n>=21&&n<=35) return String.fromCharCode(0x3251+n-21);
+          if(n>=36&&n<=50) return String.fromCharCode(0x32b1+n-36);
+          return n;
+        };
+        seq=state.sgfMoves.map((m,i)=>{
+          const c=letters[m.col];
+          const r=state.boardSize-m.row;
+          const mark=m.color===1?'■':'□';
+          return `${mark}${circle(i+1)} ${c}${r}`;
+        }).join(' ');
+      }
+      canvas.width=img.width;
+      const ctx=canvas.getContext('2d');
       ctx.font='24px sans-serif';
       ctx.textAlign='center';
-      ctx.fillText(seq,canvas.width/2,img.height+35);
-    }
+      let lines=[];
+      if(seq){
+        const maxW=canvas.width-20;
+        const words=seq.split(' ');
+        let line='';
+        for(const w of words){
+          const test=line?line+' '+w:w;
+          if(ctx.measureText(test).width>maxW && line){
+            lines.push(line);
+            line=w;
+          }else{
+            line=test;
+          }
+        }
+        if(line) lines.push(line);
+      }
+      canvas.height=img.height + lines.length*30;
+      ctx.drawImage(img,0,0);
+      if(lines.length){
+        ctx.fillStyle='#000';
+        for(let i=0;i<lines.length;i++){
+          ctx.fillText(lines[i],canvas.width/2,img.height+30*(i+0.8));
+        }
+      }
     URL.revokeObjectURL(url);
     canvas.toBlob(async b=>{
       try{
@@ -463,10 +486,17 @@ function updateInfo(){
   infoEl.textContent=`盤サイズ: ${state.boardSize}路　モード: ${modeText}　次の手番: ${colorText[turnColor]}`;
   if(state.numberMode && state.sgfMoves.length){
     const letters='ABCDEFGHJKLMNOPQRSTUV'.slice(0,state.boardSize).split('');
+    const circle=n=>{
+      if(n>=1&&n<=20) return String.fromCharCode(0x2460+n-1);
+      if(n>=21&&n<=35) return String.fromCharCode(0x3251+n-21);
+      if(n>=36&&n<=50) return String.fromCharCode(0x32b1+n-36);
+      return n;
+    };
     const seq=state.sgfMoves.map((m,i)=>{
       const c=letters[m.col];
       const r=state.boardSize-m.row;
-      return `${i+1}(${colorText[m.color]}) ${c}${r}`;
+      const mark=m.color===1?'■':'□';
+      return `${mark}${circle(i+1)} ${c}${r}`;
     }).join(' ');
     movesEl.textContent=seq;
   }else{


### PR DESCRIPTION
## Summary
- improve move notation in display and export
- wrap move sequence when saving image so nothing is cut off

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68468838ddd48329898796d913366db1