### PR TITLE
Add drag stone placement

### DIFF
--- a/tumego.js
+++ b/tumego.js
@@ -456,7 +456,11 @@ function placeAtEvent(evt){
 
 svg.addEventListener('pointerdown',e=>{
   if(e.button===2) e.preventDefault();
-  dragColor = e.button===0 ? 1 : e.button===2 ? 2 : null;
+  if(state.mode==='alt' && e.button===0){
+    dragColor = null; // follow alternating turn
+  }else{
+    dragColor = e.button===0 ? 1 : e.button===2 ? 2 : null;
+  }
   dragging = true;
   lastPos = null;
   svg.setPointerCapture(e.pointerId);


### PR DESCRIPTION
## Summary
- add pointer events for dragging placement
- allow left/right click color selection
- prevent context menu on right click

## Testing
- `node --check tumego.js`

------
https://chatgpt.com/codex/tasks/task_e_684a20fb40f8832999b36cb7f9780de5